### PR TITLE
fix: Prevent crash due to NaN

### DIFF
--- a/src/Stride.CommunityToolkit/Engine/TransformExtensions.cs
+++ b/src/Stride.CommunityToolkit/Engine/TransformExtensions.cs
@@ -577,7 +577,7 @@ public static class TransformExtensions
         }
         else
         {
-            // Prevents crash caused by NaN values due to entities being directly behind eachother.
+            // Prevents crash caused by NaN values due to entities being directly behind each other.
             // This does mean that there is an angle where the entity will not rotate.
             var angle = Quaternion.AngleBetween(transform.Rotation, lookRotation);
             if (!float.IsNaN(angle))


### PR DESCRIPTION
https://discord.com/channels/500285081265635328/740163288746426368/1295975867645825046

There was a specific angle between entities that would cause a NaN exception. This is a simple check to just not move the entity if that is the case.

There is probably a better way to do this since now when the entities are at that specific angle `LookAt` will do nothing.