### PR TITLE
chore: NuGet packages bumped

### DIFF
--- a/examples/code-only/Example04_MyraUI/Example04_MyraUI.csproj
+++ b/examples/code-only/Example04_MyraUI/Example04_MyraUI.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Myra.Stride" Version="1.5.9" />
+      <PackageReference Include="Myra.Stride" Version="1.5.10" />
     </ItemGroup>
 
 </Project>

--- a/tools/Stride.CommunityToolkit.Examples.Launcher/Stride.CommunityToolkit.Examples.Launcher.csproj
+++ b/tools/Stride.CommunityToolkit.Examples.Launcher/Stride.CommunityToolkit.Examples.Launcher.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.3.8" />
-        <PackageReference Include="Avalonia.Desktop" Version="11.3.8" />
-        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.8" />
+        <PackageReference Include="Avalonia" Version="11.3.9" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.3.9" />
+        <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.9" />
     </ItemGroup>
 
     <!-- Link discovery code from Examples project -->

--- a/tools/Stride.CommunityToolkit.Examples.MetadataGenerator/Stride.CommunityToolkit.Examples.MetadataGenerator.csproj
+++ b/tools/Stride.CommunityToolkit.Examples.MetadataGenerator/Stride.CommunityToolkit.Examples.MetadataGenerator.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
         <PackageReference Include="System.CommandLine" Version="2.0.0" />
         <PackageReference Include="YamlDotNet" Version="16.3.0" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
+        <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
         <PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />


### PR DESCRIPTION
chore: NuGet packages bumped

#### PR Classification
Dependency updates to incorporate bug fixes and improvements.

#### PR Summary
This pull request updates NuGet package versions across multiple project files to ensure compatibility and leverage the latest enhancements.  
- `Example04_MyraUI.csproj`: Updated `Myra.Stride` from `1.5.9` to `1.5.10`.  
- `Stride.CommunityToolkit.Examples.Launcher.csproj`: Updated `Avalonia`, `Avalonia.Desktop`, and `Avalonia.Themes.Fluent` from `11.3.8` to `11.3.9`.  
- `Stride.CommunityToolkit.Examples.MetadataGenerator.csproj`: Updated `Serilog.Extensions.Logging` from `9.0.2` to `10.0.0`.  
