### PR TITLE
ci: Update workflow actions and .NET version

### DIFF
--- a/.github/workflows/bump-stride-nuget-packages.yml
+++ b/.github/workflows/bump-stride-nuget-packages.yml
@@ -9,12 +9,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Install dotnet-outdated tool
         run: |

--- a/.github/workflows/dotnet-build-test.yml
+++ b/.github/workflows/dotnet-build-test.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout Stride Community Toolkit
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: .NET Setup
       uses: actions/setup-dotnet@v5

--- a/.github/workflows/dotnet-nuget.yml
+++ b/.github/workflows/dotnet-nuget.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout Stride Community Toolkit
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: .NET Setup
       uses: actions/setup-dotnet@v5

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -29,7 +29,7 @@ jobs:
     #  run: dotnet --info
 
     - name: Checkout Stride Community Toolkit
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
@@ -49,7 +49,7 @@ jobs:
       run: docfx docfx.json
 
     - name: Upload Pages artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with:
         path: docs/_site
 


### PR DESCRIPTION
ci: Update workflow actions and .NET version

- bump-stride-nuget-packages.yml - Upgrade actions/checkout to v6 and set .NET version to 10.0.x
- dotnet-build-test.yml, dotnet-nuget.yml, github-pages.yml - Upgrade actions/checkout to v6 and confirm .NET version as 10.0.x
- github-pages.yml - Upgrade actions/upload-pages-artifact to v4
- Ensure CI/CD pipelines use latest tooling and dependencies