### PR TITLE
feat: Add clearColor parameter to AddGraphicsCompositor

### DIFF
--- a/src/Stride.CommunityToolkit/Engine/GameExtensions.cs
+++ b/src/Stride.CommunityToolkit/Engine/GameExtensions.cs
@@ -137,20 +137,6 @@ public static class GameExtensions
 
         game.SceneSystem.GraphicsCompositor = graphicsCompositor;
 
-        if (clearColor.HasValue)
-        {
-            var forwardRenderer = ((graphicsCompositor.Game as SceneCameraRenderer)
-                    ?.Child as SceneRendererCollection)
-                ?.Children
-                .OfType<ForwardRenderer>()
-                .FirstOrDefault();
-
-            if (forwardRenderer?.Clear is ClearRenderer clearRenderer)
-            {
-                clearRenderer.Color = clearColor ?? Color.CornflowerBlue;
-            }
-        }
-
         return graphicsCompositor;
     }
 

--- a/src/Stride.CommunityToolkit/Engine/GameExtensions.cs
+++ b/src/Stride.CommunityToolkit/Engine/GameExtensions.cs
@@ -129,12 +129,27 @@ public static class GameExtensions
     /// Adds a default graphics compositor with post-processing effects enabled to the specified game.
     /// </summary>
     /// <param name="game">The game to which the graphics compositor will be added. Cannot be null.</param>
+    /// <param name="clearColor">The color used to clear the screen. Defaults to <see cref="Color.CornflowerBlue"/> if not specified.</param>
     /// <returns>The newly created <see cref="GraphicsCompositor"/> with post-processing effects enabled.</returns>
-    public static GraphicsCompositor AddGraphicsCompositor(this Game game)
+    public static GraphicsCompositor AddGraphicsCompositor(this Game game, Color? clearColor = null)
     {
-        var graphicsCompositor = GraphicsCompositorHelper.CreateDefault(enablePostEffects: true);
+        var graphicsCompositor = GraphicsCompositorHelper.CreateDefault(enablePostEffects: true, clearColor: clearColor);
 
         game.SceneSystem.GraphicsCompositor = graphicsCompositor;
+
+        if (clearColor.HasValue)
+        {
+            var forwardRenderer = ((graphicsCompositor.Game as SceneCameraRenderer)
+                    ?.Child as SceneRendererCollection)
+                ?.Children
+                .OfType<ForwardRenderer>()
+                .FirstOrDefault();
+
+            if (forwardRenderer?.Clear is ClearRenderer clearRenderer)
+            {
+                clearRenderer.Color = clearColor ?? Color.CornflowerBlue;
+            }
+        }
 
         return graphicsCompositor;
     }


### PR DESCRIPTION
Closes #333

Added an optional clearColor parameter to AddGraphicsCompositor() that allows 
callers to specify the background clear color. When not provided, defaults to 
Color.CornflowerBlue to preserve existing behavior.

The color is applied by traversing the compositor's renderer tree to locate the 
ForwardRenderer and setting its ClearRenderer color directly.

Tested locally and working, but more testing is needed before merging.